### PR TITLE
Fix typespecs for Client.get/3 and Parser.parsed_result/0

### DIFF
--- a/lib/ex_persona/client.ex
+++ b/lib/ex_persona/client.ex
@@ -49,7 +49,7 @@ defmodule ExPersona.Client do
   @doc """
   Make a GET request to the API at the given URL.
   """
-  @spec get(String.t(), [{atom(), String.t()}], map()) ::
+  @spec get(String.t(), [{atom(), String.t()}], list()) ::
           {:ok, binary(), list()} | {:error, String.t()}
   def get(url, headers, params) do
     req_headers =

--- a/lib/ex_persona/client/parser.ex
+++ b/lib/ex_persona/client/parser.ex
@@ -19,7 +19,7 @@ defmodule ExPersona.Client.Parser do
   @typedoc """
   Either a single or list result.
   """
-  @type parsed_result :: parsed_result | parsed_list_result
+  @type parsed_result :: parsed_single_result | parsed_list_result
 
   @type parser_func :: (Result.t() -> parsed_result)
 


### PR DESCRIPTION
### Changes
1. `params` is defined as a `[{String.t()}, {String.t()}]` list, not a map.
2. `parsed_result` should reference `parsed_single_result` instead of itself.