### PR TITLE
Downcase response headers to ensure we handle mixed-casing

### DIFF
--- a/lib/ex_persona/client/result.ex
+++ b/lib/ex_persona/client/result.ex
@@ -23,8 +23,9 @@ defmodule ExPersona.Client.Result do
   @spec from_encoded(String.t(), list(), Operation.t()) :: Result.t()
   def from_encoded(body, headers, operation) when is_binary(body) do
     headers
+    |> Enum.map(fn {k, v} -> {String.downcase(k), v} end)
     |> Enum.into(%{})
-    |> Map.get("Content-Type")
+    |> Map.get("content-type")
     |> case do
       "application/json" <> _ ->
         %Result{body: body, parsed: Jason.decode!(body), operation: operation, headers: headers}


### PR DESCRIPTION
Persona sometimes sends downcased HTTP response headers. This PR updates the client to ignore casing when fetching the "content-type" header.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/550903/174401185-30066558-150b-4263-a542-679be2f879d3.png">
