### PR TITLE
Upgrade Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [22, 23, 24]
-        elixir: ['1.11.4', '1.12', '1.13']
+        otp: [24, 25]
+        elixir: ['1.13', '1.14']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{matrix.elixir}}


### PR DESCRIPTION
This PR upgrades GH actions and versions of OTP and Elixir used in Github actions. It would appear that ubuntu-latest no longer supports OTP 22 or 23 or Elixir 1.11.4 or 1.12. This replaces unsupported versions with newer versions. 

Since this is a publicly released library, we may want to hold off an be more deliberate about supported versions. Or perhaps use a different ubuntu image that allows to continue to support older versions of OTP and Elixir. 

* checkout@v3
* Drop support for OTP 22 and 23
* Add OTP 25
* Drop Elixir 1.11.4 and 1.12
* Add Elixir 1.14